### PR TITLE
feature: implement value types with Get()/Set() methods for BTHome data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Minimal package for creating and parsing [BTHome](https://bthome.io/) service da
 buf := &bthome.Payload{}
 
 // add some data
-value := bthome.DataValue{bthome.Acceleration, []byte{0x01, 0x02}}
+value := bthome.NewDataValue(bthome.Acceleration)
+value.Set(float32(1.23))
 err := buf.AddData(value)
 if err != nil {
     t.Error(err)
@@ -28,7 +29,7 @@ data := []byte{...}
 buf := bthome.NewPayload(data)
 values, _ := buf.Parse()
 for _, v := range values {
-	println(v.Type.Name, v.Value)
+	println(v.Type().Name(), v.Get())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ for _, v := range values {
 }
 ```
 
+## Examples
+
+### Thermometer
+
+Thermometer beacon device written using TinyGo.
+
+./examples/thermometer
+
+
+## CLI Tools
+
+### bthomescan
+
+Scans for any devices that are advertising BTHome packets, then displays the data.
+
+```shell
+go run ./cmd/bthomescan
+```
+
 ## Missing features
 
 - Encryption

--- a/cmd/bthomescan/main.go
+++ b/cmd/bthomescan/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/hybridgroup/go-bthome"
+	"tinygo.org/x/bluetooth"
+)
+
+var adapter = bluetooth.DefaultAdapter
+
+func main() {
+	// Enable BLE interface.
+	must("enable BLE stack", adapter.Enable())
+
+	// Start scanning.
+	println("scanning...")
+	err := adapter.Scan(func(adapter *bluetooth.Adapter, device bluetooth.ScanResult) {
+		println("found device:", device.Address.String(), device.RSSI, device.LocalName())
+		if device.ServiceData() != nil {
+			if device.ServiceData()[0].UUID == bthome.ServiceUUID {
+				println("BTHome device found")
+				payload := bthome.NewPayload(device.ServiceData()[0].Data)
+				values, err := payload.Parse()
+				if err != nil {
+					println("failed to parse payload:", err.Error())
+					return
+				}
+				for _, value := range values {
+					println(value.String())
+				}
+			}
+		}
+	})
+	must("start scan", err)
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}

--- a/examples/thermometer/main.go
+++ b/examples/thermometer/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/hybridgroup/go-bthome"
+	"tinygo.org/x/bluetooth"
+)
+
+var adapter = bluetooth.DefaultAdapter
+
+var (
+	opts = bluetooth.AdvertisementOptions{
+		LocalName:         "Go BTHome",
+		AdvertisementType: bluetooth.AdvertisingTypeScanInd,
+	}
+
+	payload         = bthome.Payload{}
+	temperatureData = bthome.NewDataValue(bthome.Temperature)
+)
+
+func main() {
+	must("enable BLE stack", adapter.Enable())
+	adv := adapter.DefaultAdvertisement()
+
+	println("advertising...")
+	address, _ := adapter.Address()
+	for {
+		payload.Reset()
+
+		temperatureData.Set(float32(randomInt(150, 250)) / float32(10))
+
+		payload.AddData(temperatureData)
+
+		opts.ServiceData = []bluetooth.ServiceDataElement{payload.ServiceData()}
+
+		must("config adv", adv.Configure(opts))
+		must("start adv", adv.Start())
+
+		println("Go BTHome /", address.MAC.String())
+		time.Sleep(time.Second)
+		adv.Stop()
+	}
+}
+
+// Returns an int >= min, < max
+func randomInt(min, max int) uint16 {
+	return uint16(min + rand.Intn(max-min))
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,14 @@ module github.com/hybridgroup/go-bthome
 
 go 1.23.0
 
-require tinygo.org/x/bluetooth v0.10.0
+require tinygo.org/x/bluetooth v0.10.1-0.20250105094942-376e2b9b1d4e
 
 require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/saltosystems/winrt-go v0.0.0-20240509164145-4f7860a3bd2b // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/soypat/cyw43439 v0.0.0-20240609122733-da9153086796 // indirect
+	github.com/soypat/cyw43439 v0.0.0-20241116210509-ae1ce0e084c5 // indirect
 	github.com/soypat/seqs v0.0.0-20240527012110-1201bab640ef // indirect
 	github.com/tinygo-org/cbgo v0.0.4 // indirect
 	github.com/tinygo-org/pio v0.0.0-20231216154340-cd888eb58899 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/soypat/cyw43439 v0.0.0-20240609122733-da9153086796 h1:1/r2URInjjFtWqT61gU7YGVCq3BRyXt/C7z4oLRF9Lo=
 github.com/soypat/cyw43439 v0.0.0-20240609122733-da9153086796/go.mod h1:1Otjk6PRhfzfcVHeWMEeku/VntFqWghUwuSQyivb2vE=
+github.com/soypat/cyw43439 v0.0.0-20241116210509-ae1ce0e084c5 h1:arwJFX1x5zq+wUp5ADGgudhMQEXKNMQOmTh+yYgkwzw=
+github.com/soypat/cyw43439 v0.0.0-20241116210509-ae1ce0e084c5/go.mod h1:1Otjk6PRhfzfcVHeWMEeku/VntFqWghUwuSQyivb2vE=
 github.com/soypat/seqs v0.0.0-20240527012110-1201bab640ef h1:phH95I9wANjTYw6bSYLZDQfNvao+HqYDom8owbNa0P4=
 github.com/soypat/seqs v0.0.0-20240527012110-1201bab640ef/go.mod h1:oCVCNGCHMKoBj97Zp9znLbQ1nHxpkmOY9X+UAGzOxc8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -39,3 +41,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 tinygo.org/x/bluetooth v0.10.0 h1:42n8qj2tuF5AfdbAUR2Nv45EhtVmbDFH6UoWnt6lzZQ=
 tinygo.org/x/bluetooth v0.10.0/go.mod h1:t/Vm2a/rslsBoqFQKCBsWQw/cmRicQq+8Tl3tj5RCRI=
+tinygo.org/x/bluetooth v0.10.1-0.20250105094942-376e2b9b1d4e h1:fKrEnVnARQNMahyYWmkhwm/SL6LbuLBFMvWxuPtG6mA=
+tinygo.org/x/bluetooth v0.10.1-0.20250105094942-376e2b9b1d4e/go.mod h1:XLRopLvxWmIbofpZSXc7BGGCpgFOV5lrZ1i/DQN0BCw=

--- a/types.go
+++ b/types.go
@@ -81,58 +81,58 @@ func (t dataType) TypeID() int {
 
 // Sensor data types
 var (
-	Acceleration        = dataType{"acceleration", 0x51, 2, "m/s²", 0.001, TypeFloat32}
-	Battery             = dataType{"battery", 0x01, 1, "%", 1, TypeInt8}
-	CO2                 = dataType{"co2", 0x12, 2, "ppm", 1, TypeInt16}
-	Conductivity        = dataType{"conductivity", 0x56, 2, "µS/cm", 1, TypeInt16}
-	Count8              = dataType{"count", 0x09, 1, "", 1, TypeUint8}
-	Count16             = dataType{"count", 0x3D, 2, "", 1, TypeUint16}
-	Count32             = dataType{"count", 0x3E, 4, "", 1, TypeUint32}
-	CountSint8          = dataType{"count", 0x59, 1, "", 1, TypeInt8}
-	CountSint16         = dataType{"count", 0x5A, 2, "", 1, TypeInt16}
-	CountSint32         = dataType{"count", 0x5B, 4, "", 1, TypeUint32}
-	Current             = dataType{"current", 0x43, 2, "A", 0.001, TypeFloat32}
-	CurrentSint16       = dataType{"current", 0x5D, 2, "A", 0.001, TypeFloat32}
-	Dewpoint            = dataType{"dewpoint", 0x08, 2, "°C", 0.01, TypeFloat32}
-	DistanceMM          = dataType{"distance (mm)", 0x40, 2, "mm", 1, TypeUint16}
-	DistanceM           = dataType{"distance (m)", 0x41, 2, "m", 0.01, TypeFloat32}
-	Duration            = dataType{"duration", 0x42, 3, "s", 1, TypeFloat32}
-	Energy              = dataType{"energy", 0x4D, 4, "Wh", 0.001, TypeFloat32}
-	Energy24            = dataType{"energy", 0x0A, 3, "Wh", 0.001, TypeFloat32}
-	Gas24               = dataType{"gas", 0x4B, 3, "m2", 1, TypeFloat32}
-	Gas32               = dataType{"gas", 0x4C, 4, "m2", 1, TypeFloat32}
-	Gyroscope           = dataType{"gyroscope", 0x52, 2, "°/s", 0.01, TypeFloat32}
-	Humidity16          = dataType{"humidity", 0x03, 2, "%", 1, TypeFloat32}
-	Humidity8           = dataType{"humidity", 0x2E, 1, "%", 1, TypeInt8}
-	Illuminance         = dataType{"illuminance", 0x05, 3, "lux", 1, TypeFloat32}
-	MassKG              = dataType{"mass (kg)", 0x06, 2, "kg", 0.001, TypeFloat32}
-	MassLB              = dataType{"mass (lb)", 0x07, 2, "lb", 0.001, TypeFloat32}
-	Moisture16          = dataType{"moisture", 0x14, 2, "%", 1, TypeFloat32}
-	Moisture8           = dataType{"moisture", 0x2F, 1, "%", 1, TypeInt8}
-	PM25                = dataType{"pm2.5", 0x0D, 2, "µg/m³", 1, TypeInt16}
-	PM10                = dataType{"pm10", 0x0E, 2, "µg/m³", 1, TypeInt16}
-	Power               = dataType{"power", 0x0B, 3, "W", 0.001, TypeFloat32}
-	PowerSint32         = dataType{"power", 0x5C, 4, "W", 0.001, TypeFloat32}
-	Pressure            = dataType{"pressure", 0x04, 3, "hPa", 0.01, TypeFloat32}
-	Raw                 = dataType{"raw", 0x54, -1, "", 1, TypeString}
-	Rotation            = dataType{"rotation", 0x3F, 2, "°", 0.01, TypeFloat32}
-	Speed               = dataType{"speed", 0x44, 2, "m/s", 0.01, TypeFloat32}
-	TemperatureSint8    = dataType{"temperature", 0x57, 1, "°C", 0.01, TypeInt8}
-	TemperatureSint8_35 = dataType{"temperature", 0x58, 1, "°C", 0.01, TypeInt8}
-	Temperature16       = dataType{"temperature", 0x45, 2, "°C", 0.01, TypeInt16}
-	Temperature16_01    = dataType{"temperature", 0x02, 2, "°C", 0.01, TypeInt16}
-	Text                = dataType{"text", 0x53, -1, "", 1, TypeString}
-	Timestamp           = dataType{"timestamp", 0x50, 4, "s", 1, TypeFloat32}
-	TVOC                = dataType{"tvoc", 0x13, 2, "ppb", 1, TypeInt16}
-	Voltage             = dataType{"voltage", 0x0C, 2, "V", 0.001, TypeFloat32}
-	Voltage10           = dataType{"voltage", 0x4A, 2, "V", 0.001, TypeFloat32}
-	Volume              = dataType{"volume", 0x4E, 4, "m³", 0.001, TypeFloat32}
-	Volume16            = dataType{"volume", 0x47, 2, "m³", 0.001, TypeFloat32}
-	VolumeML            = dataType{"volume", 0x48, 2, "mL", 1, TypeUint16}
-	VolumeStorage       = dataType{"volume storage", 0x55, 4, "m³", 0.001, TypeFloat32}
-	VolumeFlowRate      = dataType{"volume flow rate", 0x49, 2, "m³/s", 0.001, TypeFloat32}
-	UVIndex             = dataType{"UV index", 0x46, 1, "", 1, TypeFloat32}
-	Water               = dataType{"water", 0x4F, 4, "L", 0.001, TypeFloat32}
+	Acceleration   = dataType{"acceleration", 0x51, 2, "m/s²", 0.001, TypeFloat32}
+	Battery        = dataType{"battery", 0x01, 1, "%", 1, TypeInt8}
+	CO2            = dataType{"co2", 0x12, 2, "ppm", 1, TypeInt16}
+	Conductivity   = dataType{"conductivity", 0x56, 2, "µS/cm", 1, TypeInt16}
+	Count8         = dataType{"count", 0x09, 1, "", 1, TypeUint8}
+	Count16        = dataType{"count", 0x3D, 2, "", 1, TypeUint16}
+	Count32        = dataType{"count", 0x3E, 4, "", 1, TypeUint32}
+	CountSint8     = dataType{"count", 0x59, 1, "", 1, TypeInt8}
+	CountSint16    = dataType{"count", 0x5A, 2, "", 1, TypeInt16}
+	CountSint32    = dataType{"count", 0x5B, 4, "", 1, TypeUint32}
+	Current        = dataType{"current", 0x43, 2, "A", 0.001, TypeFloat32}
+	CurrentSint16  = dataType{"current", 0x5D, 2, "A", 0.001, TypeFloat32}
+	Dewpoint       = dataType{"dewpoint", 0x08, 2, "°C", 0.01, TypeFloat32}
+	DistanceMM     = dataType{"distance (mm)", 0x40, 2, "mm", 1, TypeUint16}
+	DistanceM      = dataType{"distance (m)", 0x41, 2, "m", 0.01, TypeFloat32}
+	Duration       = dataType{"duration", 0x42, 3, "s", 1, TypeFloat32}
+	Energy         = dataType{"energy", 0x4D, 4, "Wh", 0.001, TypeFloat32}
+	Energy24       = dataType{"energy", 0x0A, 3, "Wh", 0.001, TypeFloat32}
+	Gas24          = dataType{"gas", 0x4B, 3, "m2", 1, TypeFloat32}
+	Gas32          = dataType{"gas", 0x4C, 4, "m2", 1, TypeFloat32}
+	Gyroscope      = dataType{"gyroscope", 0x52, 2, "°/s", 0.01, TypeFloat32}
+	Humidity16     = dataType{"humidity", 0x03, 2, "%", 1, TypeFloat32}
+	Humidity8      = dataType{"humidity", 0x2E, 1, "%", 1, TypeInt8}
+	Illuminance    = dataType{"illuminance", 0x05, 3, "lux", 1, TypeFloat32}
+	MassKG         = dataType{"mass (kg)", 0x06, 2, "kg", 0.001, TypeFloat32}
+	MassLB         = dataType{"mass (lb)", 0x07, 2, "lb", 0.001, TypeFloat32}
+	Moisture16     = dataType{"moisture", 0x14, 2, "%", 1, TypeFloat32}
+	Moisture8      = dataType{"moisture", 0x2F, 1, "%", 1, TypeInt8}
+	PM25           = dataType{"pm2.5", 0x0D, 2, "µg/m³", 1, TypeInt16}
+	PM10           = dataType{"pm10", 0x0E, 2, "µg/m³", 1, TypeInt16}
+	Power          = dataType{"power", 0x0B, 3, "W", 0.001, TypeFloat32}
+	PowerSint32    = dataType{"power", 0x5C, 4, "W", 0.001, TypeFloat32}
+	Pressure       = dataType{"pressure", 0x04, 3, "hPa", 0.01, TypeFloat32}
+	Raw            = dataType{"raw", 0x54, -1, "", 1, TypeString}
+	Rotation       = dataType{"rotation", 0x3F, 2, "°", 0.01, TypeFloat32}
+	Speed          = dataType{"speed", 0x44, 2, "m/s", 0.01, TypeFloat32}
+	TemperatureInt = dataType{"temperature", 0x57, 1, "°C", 1, TypeInt8}
+	Temperature8   = dataType{"temperature", 0x58, 1, "°C", 0.35, TypeFloat32}
+	Temperature    = dataType{"temperature", 0x45, 2, "°C", 0.1, TypeFloat32}
+	Temperature2   = dataType{"temperature", 0x02, 2, "°C", 0.01, TypeFloat32}
+	Text           = dataType{"text", 0x53, -1, "", 1, TypeString}
+	Timestamp      = dataType{"timestamp", 0x50, 4, "s", 1, TypeFloat32}
+	TVOC           = dataType{"tvoc", 0x13, 2, "ppb", 1, TypeInt16}
+	Voltage        = dataType{"voltage", 0x0C, 2, "V", 0.001, TypeFloat32}
+	Voltage10      = dataType{"voltage", 0x4A, 2, "V", 0.001, TypeFloat32}
+	Volume         = dataType{"volume", 0x4E, 4, "m³", 0.001, TypeFloat32}
+	Volume16       = dataType{"volume", 0x47, 2, "m³", 0.001, TypeFloat32}
+	VolumeML       = dataType{"volume", 0x48, 2, "mL", 1, TypeUint16}
+	VolumeStorage  = dataType{"volume storage", 0x55, 4, "m³", 0.001, TypeFloat32}
+	VolumeFlowRate = dataType{"volume flow rate", 0x49, 2, "m³/s", 0.001, TypeFloat32}
+	UVIndex        = dataType{"UV index", 0x46, 1, "", 1, TypeFloat32}
+	Water          = dataType{"water", 0x4F, 4, "L", 0.001, TypeFloat32}
 )
 
 // Binary Sensor data should always be an uint8 of a single byte. Its value should be 1 for on, and 0 for off.
@@ -205,10 +205,10 @@ var (
 		Raw,
 		Rotation,
 		Speed,
-		TemperatureSint8,
-		TemperatureSint8_35,
-		Temperature16,
-		Temperature16_01,
+		TemperatureInt,
+		Temperature8,
+		Temperature,
+		Temperature2,
 		Text,
 		Timestamp,
 		TVOC,

--- a/types.go
+++ b/types.go
@@ -1,6 +1,8 @@
 package bthome
 
-import "tinygo.org/x/bluetooth"
+import (
+	"tinygo.org/x/bluetooth"
+)
 
 var ServiceUUID = bluetooth.New16BitUUID(0xFCD2)
 
@@ -8,22 +10,70 @@ var ServiceUUID = bluetooth.New16BitUUID(0xFCD2)
 // the capabilities of the device.
 const DeviceInformation = 0x40
 
-// DataType represents a data type that can be added to the service data payload.
-type DataType struct {
-	// Name of the data type
-	Name string
+const (
+	TypeInt8 = iota
+	TypeInt16
+	TypeInt32
+	TypeUint8
+	TypeUint16
+	TypeUint32
+	TypeFloat32
+	TypeString
+	TypeBool
+)
 
-	// ID of the data type
-	ID byte
-
-	// Size of the data type in bytes
-	Size int
+type DataType interface {
+	Name() string
+	ID() byte
+	Size() int
+	Unit() string
+	Factor() float32
+	TypeID() int
 }
 
-// DataValue represents an individual data value in the service data payload.
-type DataValue struct {
-	Type  DataType
-	Value []byte
+// dataType represents a data type that can be added to the service data payload.
+type dataType struct {
+	// Name of the data type
+	name string
+
+	// ID of the data type
+	id byte
+
+	// Size of the data type in bytes
+	size int
+
+	// Unit of the data type
+	unit string
+
+	// Factor to convert the data type to bytes unit
+	factor float32
+
+	// TypeID of the data type
+	typeID int
+}
+
+func (t dataType) Name() string {
+	return t.name
+}
+
+func (t dataType) ID() byte {
+	return t.id
+}
+
+func (t dataType) Size() int {
+	return t.size
+}
+
+func (t dataType) Unit() string {
+	return t.unit
+}
+
+func (t dataType) Factor() float32 {
+	return t.factor
+}
+
+func (t dataType) TypeID() int {
+	return t.typeID
 }
 
 // See full list of field types:
@@ -31,94 +81,94 @@ type DataValue struct {
 
 // Sensor data types
 var (
-	Acceleration        = DataType{"acceleration", 0x51, 2}
-	Battery             = DataType{"battery", 0x01, 1}
-	CO2                 = DataType{"co2", 0x12, 2}
-	Conductivity        = DataType{"conductivity", 0x56, 2}
-	Count8              = DataType{"count", 0x09, 1}
-	Count16             = DataType{"count", 0x3D, 2}
-	Count32             = DataType{"count", 0x3E, 4}
-	CountSint8          = DataType{"count", 0x59, 1}
-	CountSint16         = DataType{"count", 0x5A, 2}
-	CountSint32         = DataType{"count", 0x5B, 4}
-	Current             = DataType{"current", 0x43, 2}
-	CurrentSint16       = DataType{"current", 0x5D, 2}
-	Dewpoint            = DataType{"dewpoint", 0x08, 2}
-	DistanceMM          = DataType{"distance (mm)", 0x40, 2}
-	DistanceM           = DataType{"distance (m)", 0x41, 2}
-	Duration            = DataType{"duration", 0x42, 3}
-	Energy              = DataType{"energy", 0x4D, 4}
-	Energy24            = DataType{"energy", 0x0A, 3}
-	Gas24               = DataType{"gas", 0x4B, 3}
-	Gas32               = DataType{"gas", 0x4C, 4}
-	Gyroscope           = DataType{"gyroscope", 0x52, 2}
-	Humidity16          = DataType{"humidity", 0x03, 2}
-	Humidity8           = DataType{"humidity", 0x2E, 1}
-	Illuminance         = DataType{"illuminance", 0x05, 3}
-	MassKG              = DataType{"mass (kg)", 0x06, 2}
-	MassLB              = DataType{"mass (lb)", 0x07, 2}
-	Moisture16          = DataType{"moisture", 0x14, 2}
-	Moisture8           = DataType{"moisture", 0x2F, 1}
-	PM25                = DataType{"pm2.5", 0x0D, 2}
-	PM10                = DataType{"pm10", 0x0E, 2}
-	Power               = DataType{"power", 0x0B, 3}
-	PowerSint32         = DataType{"power", 0x5C, 4}
-	Pressure            = DataType{"pressure", 0x04, 3}
-	Raw                 = DataType{"raw", 0x54, -1}
-	Rotation            = DataType{"rotation", 0x3F, 2}
-	Speed               = DataType{"speed", 0x44, 2}
-	TemperatureSint8    = DataType{"temperature", 0x57, 1}
-	TemperatureSint8_35 = DataType{"temperature", 0x58, 1}
-	Temperature16       = DataType{"temperature", 0x45, 2}
-	Temperature16_01    = DataType{"temperature", 0x02, 2}
-	Text                = DataType{"text", 0x53, -1}
-	Timestamp           = DataType{"timestamp", 0x50, 4}
-	TVOC                = DataType{"tvoc", 0x13, 2}
-	Voltage             = DataType{"voltage", 0x0C, 2}
-	Voltage10           = DataType{"voltage", 0x4A, 2}
-	Volume              = DataType{"volume", 0x4E, 4}
-	Volume16            = DataType{"volume", 0x47, 2}
-	VolumeML            = DataType{"volume", 0x48, 2}
-	VolumeStorage       = DataType{"volume storage", 0x55, 4}
-	VolumeFlowRate      = DataType{"volume flow rate", 0x49, 2}
-	UVIndex             = DataType{"UV index", 0x46, 1}
-	Water               = DataType{"water", 0x4F, 4}
+	Acceleration        = dataType{"acceleration", 0x51, 2, "m/s²", 0.001, TypeFloat32}
+	Battery             = dataType{"battery", 0x01, 1, "%", 1, TypeInt8}
+	CO2                 = dataType{"co2", 0x12, 2, "ppm", 1, TypeInt16}
+	Conductivity        = dataType{"conductivity", 0x56, 2, "µS/cm", 1, TypeInt16}
+	Count8              = dataType{"count", 0x09, 1, "", 1, TypeUint8}
+	Count16             = dataType{"count", 0x3D, 2, "", 1, TypeUint16}
+	Count32             = dataType{"count", 0x3E, 4, "", 1, TypeUint32}
+	CountSint8          = dataType{"count", 0x59, 1, "", 1, TypeInt8}
+	CountSint16         = dataType{"count", 0x5A, 2, "", 1, TypeInt16}
+	CountSint32         = dataType{"count", 0x5B, 4, "", 1, TypeUint32}
+	Current             = dataType{"current", 0x43, 2, "A", 0.001, TypeFloat32}
+	CurrentSint16       = dataType{"current", 0x5D, 2, "A", 0.001, TypeFloat32}
+	Dewpoint            = dataType{"dewpoint", 0x08, 2, "°C", 0.01, TypeFloat32}
+	DistanceMM          = dataType{"distance (mm)", 0x40, 2, "mm", 1, TypeUint16}
+	DistanceM           = dataType{"distance (m)", 0x41, 2, "m", 0.01, TypeFloat32}
+	Duration            = dataType{"duration", 0x42, 3, "s", 1, TypeFloat32}
+	Energy              = dataType{"energy", 0x4D, 4, "Wh", 0.001, TypeFloat32}
+	Energy24            = dataType{"energy", 0x0A, 3, "Wh", 0.001, TypeFloat32}
+	Gas24               = dataType{"gas", 0x4B, 3, "m2", 1, TypeFloat32}
+	Gas32               = dataType{"gas", 0x4C, 4, "m2", 1, TypeFloat32}
+	Gyroscope           = dataType{"gyroscope", 0x52, 2, "°/s", 0.01, TypeFloat32}
+	Humidity16          = dataType{"humidity", 0x03, 2, "%", 1, TypeFloat32}
+	Humidity8           = dataType{"humidity", 0x2E, 1, "%", 1, TypeInt8}
+	Illuminance         = dataType{"illuminance", 0x05, 3, "lux", 1, TypeFloat32}
+	MassKG              = dataType{"mass (kg)", 0x06, 2, "kg", 0.001, TypeFloat32}
+	MassLB              = dataType{"mass (lb)", 0x07, 2, "lb", 0.001, TypeFloat32}
+	Moisture16          = dataType{"moisture", 0x14, 2, "%", 1, TypeFloat32}
+	Moisture8           = dataType{"moisture", 0x2F, 1, "%", 1, TypeInt8}
+	PM25                = dataType{"pm2.5", 0x0D, 2, "µg/m³", 1, TypeInt16}
+	PM10                = dataType{"pm10", 0x0E, 2, "µg/m³", 1, TypeInt16}
+	Power               = dataType{"power", 0x0B, 3, "W", 0.001, TypeFloat32}
+	PowerSint32         = dataType{"power", 0x5C, 4, "W", 0.001, TypeFloat32}
+	Pressure            = dataType{"pressure", 0x04, 3, "hPa", 0.01, TypeFloat32}
+	Raw                 = dataType{"raw", 0x54, -1, "", 1, TypeString}
+	Rotation            = dataType{"rotation", 0x3F, 2, "°", 0.01, TypeFloat32}
+	Speed               = dataType{"speed", 0x44, 2, "m/s", 0.01, TypeFloat32}
+	TemperatureSint8    = dataType{"temperature", 0x57, 1, "°C", 0.01, TypeInt8}
+	TemperatureSint8_35 = dataType{"temperature", 0x58, 1, "°C", 0.01, TypeInt8}
+	Temperature16       = dataType{"temperature", 0x45, 2, "°C", 0.01, TypeInt16}
+	Temperature16_01    = dataType{"temperature", 0x02, 2, "°C", 0.01, TypeInt16}
+	Text                = dataType{"text", 0x53, -1, "", 1, TypeString}
+	Timestamp           = dataType{"timestamp", 0x50, 4, "s", 1, TypeFloat32}
+	TVOC                = dataType{"tvoc", 0x13, 2, "ppb", 1, TypeInt16}
+	Voltage             = dataType{"voltage", 0x0C, 2, "V", 0.001, TypeFloat32}
+	Voltage10           = dataType{"voltage", 0x4A, 2, "V", 0.001, TypeFloat32}
+	Volume              = dataType{"volume", 0x4E, 4, "m³", 0.001, TypeFloat32}
+	Volume16            = dataType{"volume", 0x47, 2, "m³", 0.001, TypeFloat32}
+	VolumeML            = dataType{"volume", 0x48, 2, "mL", 1, TypeUint16}
+	VolumeStorage       = dataType{"volume storage", 0x55, 4, "m³", 0.001, TypeFloat32}
+	VolumeFlowRate      = dataType{"volume flow rate", 0x49, 2, "m³/s", 0.001, TypeFloat32}
+	UVIndex             = dataType{"UV index", 0x46, 1, "", 1, TypeFloat32}
+	Water               = dataType{"water", 0x4F, 4, "L", 0.001, TypeFloat32}
 )
 
 // Binary Sensor data should always be an uint8 of a single byte. Its value should be 1 for on, and 0 for off.
 var (
-	BatteryLow      = DataType{"battery", 0x15, 1}
-	BatteryCharging = DataType{"battery charging", 0x16, 1}
-	CarbonMonoxide  = DataType{"carbon monoxide", 0x17, 1}
-	Cold            = DataType{"cold", 0x18, 1}
-	Connectivity    = DataType{"connectivity", 0x19, 1}
-	Door            = DataType{"door", 0x1A, 1}
-	GarageDoor      = DataType{"garage door", 0x1B, 1}
-	Gas             = DataType{"gas", 0x1C, 1}
-	GenericBoolean  = DataType{"generic boolean", 0x0F, 1}
-	Heat            = DataType{"heat", 0x1D, 1}
-	Light           = DataType{"light", 0x1E, 1}
-	Lock            = DataType{"lock", 0x1F, 1}
-	Moisture        = DataType{"moisture", 0x20, 1}
-	Motion          = DataType{"motion", 0x21, 1}
-	Moving          = DataType{"moving", 0x22, 1}
-	Occupancy       = DataType{"occupancy", 0x23, 1}
-	Opening         = DataType{"opening", 0x11, 1}
-	Plug            = DataType{"plug", 0x24, 1}
-	Powered         = DataType{"power", 0x10, 1}
-	Presence        = DataType{"presence", 0x25, 1}
-	Problem         = DataType{"problem", 0x26, 1}
-	Running         = DataType{"running", 0x27, 1}
-	Safety          = DataType{"safety", 0x28, 1}
-	Smoke           = DataType{"smoke", 0x29, 1}
-	Sound           = DataType{"sound", 0x2A, 1}
-	Tamper          = DataType{"tamper", 0x2B, 1}
-	Vibration       = DataType{"vibration", 0x2C, 1}
-	Window          = DataType{"window", 0x2D, 1}
+	BatteryLow      = dataType{"battery", 0x15, 1, "", 1, TypeBool}
+	BatteryCharging = dataType{"battery charging", 0x16, 1, "", 1, TypeBool}
+	CarbonMonoxide  = dataType{"carbon monoxide", 0x17, 1, "", 1, TypeBool}
+	Cold            = dataType{"cold", 0x18, 1, "", 1, TypeBool}
+	Connectivity    = dataType{"connectivity", 0x19, 1, "", 1, TypeBool}
+	Door            = dataType{"door", 0x1A, 1, "", 1, TypeBool}
+	GarageDoor      = dataType{"garage door", 0x1B, 1, "", 1, TypeBool}
+	Gas             = dataType{"gas", 0x1C, 1, "", 1, TypeBool}
+	GenericBoolean  = dataType{"generic boolean", 0x0F, 1, "", 1, TypeBool}
+	Heat            = dataType{"heat", 0x1D, 1, "", 1, TypeBool}
+	Light           = dataType{"light", 0x1E, 1, "", 1, TypeBool}
+	Lock            = dataType{"lock", 0x1F, 1, "", 1, TypeBool}
+	Moisture        = dataType{"moisture", 0x20, 1, "", 1, TypeBool}
+	Motion          = dataType{"motion", 0x21, 1, "", 1, TypeBool}
+	Moving          = dataType{"moving", 0x22, 1, "", 1, TypeBool}
+	Occupancy       = dataType{"occupancy", 0x23, 1, "", 1, TypeBool}
+	Opening         = dataType{"opening", 0x11, 1, "", 1, TypeBool}
+	Plug            = dataType{"plug", 0x24, 1, "", 1, TypeBool}
+	Powered         = dataType{"power", 0x10, 1, "", 1, TypeBool}
+	Presence        = dataType{"presence", 0x25, 1, "", 1, TypeBool}
+	Problem         = dataType{"problem", 0x26, 1, "", 1, TypeBool}
+	Running         = dataType{"running", 0x27, 1, "", 1, TypeBool}
+	Safety          = dataType{"safety", 0x28, 1, "", 1, TypeBool}
+	Smoke           = dataType{"smoke", 0x29, 1, "", 1, TypeBool}
+	Sound           = dataType{"sound", 0x2A, 1, "", 1, TypeBool}
+	Tamper          = dataType{"tamper", 0x2B, 1, "", 1, TypeBool}
+	Vibration       = dataType{"vibration", 0x2C, 1, "", 1, TypeBool}
+	Window          = dataType{"window", 0x2D, 1, "", 1, TypeBool}
 )
 
 var (
-	DataTypes = []DataType{
+	DataTypes = []dataType{
 		Acceleration,
 		Battery,
 		CO2,
@@ -204,9 +254,9 @@ var (
 
 func FindDataType(id byte) DataType {
 	for _, t := range DataTypes {
-		if t.ID == id {
-			return t
+		if t.ID() == id {
+			return &t
 		}
 	}
-	return DataType{}
+	return nil
 }

--- a/values.go
+++ b/values.go
@@ -1,0 +1,128 @@
+package bthome
+
+import (
+	"encoding/binary"
+)
+
+// GetDataValue returns a new DataValuer for the given data type and data.
+func GetDataValue(typ DataType, data []byte) DataValuer {
+	switch typ.TypeID() {
+	case TypeFloat32:
+		return Float32Value{DataValue{DataType: typ, Value: data}}
+	case TypeInt8:
+		return Int8Value{DataValue{DataType: typ, Value: data}}
+	case TypeInt16:
+		return Int16Value{DataValue{DataType: typ, Value: data}}
+	case TypeBool:
+		return BoolValue{DataValue{DataType: typ, Value: data}}
+	}
+
+	return nil
+}
+
+// NewDataValue returns a new DataValuer for the given data type.
+func NewDataValue(typ DataType) DataValuer {
+	switch typ.TypeID() {
+	case TypeFloat32:
+		return Float32Value{DataValue{DataType: typ, Value: make([]byte, typ.Size())}}
+	case TypeInt8:
+		return Int8Value{DataValue{DataType: typ, Value: make([]byte, typ.Size())}}
+	case TypeInt16:
+		return Int16Value{DataValue{DataType: typ, Value: make([]byte, typ.Size())}}
+	case TypeBool:
+		return BoolValue{DataValue{DataType: typ, Value: make([]byte, typ.Size())}}
+	}
+
+	return nil
+}
+
+// DataValuer is an interface for data values in the service data payload.
+type DataValuer interface {
+	Type() DataType
+	Data() []byte
+	Get() any
+	Set(any)
+}
+
+// DataValue represents an individual data value in the service data payload.
+type DataValue struct {
+	DataType DataType
+	Value    []byte
+}
+
+// Type returns the data type of the data value.
+func (d DataValue) Type() DataType {
+	return d.DataType
+}
+
+// Data returns the raw data of the data value.
+func (d DataValue) Data() []byte {
+	return d.Value
+}
+
+// Float32Value represents a float32 data value in the service data payload.
+type Float32Value struct {
+	DataValue
+}
+
+// Get returns the float32 value of the data value.
+func (d Float32Value) Get() any {
+	return float32(float32(binary.LittleEndian.Uint16(d.Value)) * d.DataType.Factor())
+}
+
+// Set sets the float32 value of the data value.
+func (d Float32Value) Set(v any) {
+	var val float32
+	switch v := v.(type) {
+	case float32:
+		val = v / float32(d.DataType.Factor())
+	case float64:
+		val = float32(v) / float32(d.DataType.Factor())
+	}
+
+	binary.LittleEndian.PutUint16(d.Value, uint16(val))
+}
+
+type Int8Value struct {
+	DataValue
+}
+
+func (d Int8Value) Get() any {
+	return int(d.Value[0]) / int(d.DataType.Factor())
+}
+
+func (d Int8Value) Set(v any) {
+	val := v.(int) * int(d.DataType.Factor())
+	d.Value[0] = byte(val)
+}
+
+type Int16Value struct {
+	DataValue
+}
+
+func (d Int16Value) Get() any {
+	val := binary.LittleEndian.Uint16(d.Value)
+	return int(float32(val) / d.DataType.Factor())
+}
+
+func (d Int16Value) Set(v any) {
+	val := v.(int) * int(d.DataType.Factor())
+	binary.LittleEndian.PutUint16(d.Value, uint16(val))
+}
+
+type BoolValue struct {
+	DataValue
+}
+
+func (d BoolValue) Get() any {
+	return d.Value[0] != 0
+}
+
+func (d BoolValue) Set(v any) {
+	val := v.(bool)
+	if val {
+		d.Value[0] = 1
+	} else {
+		d.Value[0] = 0
+	}
+}

--- a/values.go
+++ b/values.go
@@ -2,6 +2,7 @@ package bthome
 
 import (
 	"encoding/binary"
+	"strconv"
 )
 
 // GetDataValue returns a new DataValuer for the given data type and data.
@@ -42,6 +43,7 @@ type DataValuer interface {
 	Data() []byte
 	Get() any
 	Set(any)
+	String() string
 }
 
 // DataValue represents an individual data value in the service data payload.
@@ -83,6 +85,10 @@ func (d Float32Value) Set(v any) {
 	binary.LittleEndian.PutUint16(d.Value, uint16(val))
 }
 
+func (d Float32Value) String() string {
+	return d.Type().Name() + ": " + strconv.FormatFloat(float64(d.Get().(float32)), 'f', -1, 32)
+}
+
 type Int8Value struct {
 	DataValue
 }
@@ -94,6 +100,10 @@ func (d Int8Value) Get() any {
 func (d Int8Value) Set(v any) {
 	val := v.(int) * int(d.DataType.Factor())
 	d.Value[0] = byte(val)
+}
+
+func (d Int8Value) String() string {
+	return d.Type().Name() + ": " + strconv.Itoa(d.Get().(int))
 }
 
 type Int16Value struct {
@@ -108,6 +118,10 @@ func (d Int16Value) Get() any {
 func (d Int16Value) Set(v any) {
 	val := v.(int) * int(d.DataType.Factor())
 	binary.LittleEndian.PutUint16(d.Value, uint16(val))
+}
+
+func (d Int16Value) String() string {
+	return d.Type().Name() + ": " + strconv.Itoa(d.Get().(int))
 }
 
 type BoolValue struct {
@@ -125,4 +139,8 @@ func (d BoolValue) Set(v any) {
 	} else {
 		d.Value[0] = 0
 	}
+}
+
+func (d BoolValue) String() string {
+	return d.Type().Name() + ": " + strconv.FormatBool(d.Get().(bool))
 }

--- a/values_test.go
+++ b/values_test.go
@@ -1,0 +1,88 @@
+package bthome
+
+import "testing"
+
+func TestFloatDataValue(t *testing.T) {
+	buf := &Payload{}
+
+	value := NewDataValue(Acceleration)
+	testvalue := float32(1.23)
+	value.Set(testvalue)
+
+	err := buf.AddData(value)
+	if err != nil {
+		t.Error(err)
+	}
+
+	data, err := buf.GetData(Acceleration)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if data.Get() != testvalue {
+		t.Error("data mismatch", data.Data()[0], data.Data()[1], data.Get())
+	}
+}
+
+func TestInt8DataValue(t *testing.T) {
+	buf := &Payload{}
+
+	value := NewDataValue(Battery)
+	value.Set(100)
+
+	err := buf.AddData(value)
+	if err != nil {
+		t.Error(err)
+	}
+
+	data, err := buf.GetData(Battery)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if data.Get() != 100 {
+		t.Error("data mismatch", data.Data()[0])
+	}
+}
+
+func TestInt16DataValue(t *testing.T) {
+	buf := &Payload{}
+
+	value := NewDataValue(Conductivity)
+	value.Set(10000)
+
+	err := buf.AddData(value)
+	if err != nil {
+		t.Error(err)
+	}
+
+	data, err := buf.GetData(Conductivity)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if data.Get() != 10000 {
+		t.Error("data mismatch", data.Data()[0])
+	}
+}
+
+func TestBoolDataValue(t *testing.T) {
+	buf := &Payload{}
+
+	value := NewDataValue(Presence)
+	value.Set(true)
+
+	err := buf.AddData(value)
+	if err != nil {
+		t.Error(err)
+	}
+
+	data, err := buf.GetData(Presence)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if data.Get() != true {
+		t.Error("data mismatch", data.Data()[0])
+	}
+}


### PR DESCRIPTION
This PR implements value types with Get()/Set() methods for BTHome data types.

Makes it possible to do this:

```go
	buf := &bthome.Payload{}
	value := bthome.NewDataValue(bthome.Acceleration)
	value.Set(1.23)
	buf.AddData(value)

	val2 := bthome.NewDataValue(bthome.Humidity8)
	val2.Set(27)
	buf.AddData(val2)
```